### PR TITLE
 修复下拉选择月份，当前月份没有被选择的BUG

### DIFF
--- a/jedate/jedate.js
+++ b/jedate/jedate.js
@@ -612,7 +612,8 @@ window.console && (console = console || {log : function(){return;}});
             var ymStr = "";
             if (ymlen == 12) {
                 jeDt.each(jeDt.montharr, function(i, val) {
-                    var getmonth = jeDt.attr(jedatemonth[0], "month"), val = jeDt.digit(val);
+                    var getmonth = jeDt.attr(jedatemonth[0], "month"), val = jeDt.digit(val)  + "";
+                    val = val.replace(/\b(0+)/gi,"")/1;
                     ymStr += "<li " + (getmonth == val ? 'class="action"' :"") + ' mm="' + val + '">' + val + "月</li>";
                 });
                 jeDt.each([ mchri, mchle ], function(c, cls) {


### PR DESCRIPTION
因为`var`传来的格式是01、02、03....  
但是getMonth格式是1、2、3...  
所以造成1-9月份无法默认选择  
只修改了jedate.js，不知道jedate.min.js是怎么压缩的，自行压缩一下吧～～～～
