### PR TITLE
添加一个是否显示“确认”按钮的判断

### DIFF
--- a/jedate/jedate.js
+++ b/jedate/jedate.js
@@ -373,6 +373,8 @@ window.console && (console = console || {log : function(){return;}});
         var datehmschoose = '<div class="jedateprophms ' + (ishhmm ? "jedatepropfix" :"jedateproppos") + '"><div class="jedatepropcon"><div class="jedatehmstitle">时间选择<div class="jedatehmsclose">&times;</div></div><div class="jedateproptext">小时</div><div class="jedateproptext">分钟</div><div class="jedateproptext">秒数</div><div class="jedatehmscon jedateprophours"></div><div class="jedatehmscon jedatepropminutes"></div><div class="jedatehmscon jedatepropseconds"></div></div></div>';
         var dateHtmStr = isYYMM ? datetopStr + dateymList + datebotStr :ishhmm ? datetopStr + datehmschoose + datebotStr :datetopStr + dateymList + dateriList + datehmschoose + datebotStr;
         jeDt.html(QD(jeDt.boxCell)[0], dateHtmStr);
+        //是否显示确认按钮
+        jeDt.isBool(jeDt.opts.isOk) ? "" : jeDt.isShow(jeDt.find(".jedatebot .jedateok")[0], false);
         //是否显示清除按钮
         jeDt.isBool(jeDt.opts.isClear) ? "" : jeDt.isShow(jeDt.find(".jedatebot .jedateclear")[0], false);
         //是否显示今天按钮


### PR DESCRIPTION
我在用jeDate时，遇到一个bug。我设置最小时间是9月1日，首先选择了9月1日这一天。但是选择框内我选择了八月，虽然不能选择具体的八月某一天，但是当我点击“确认”按钮的时候，时间的值就自动把日期的值设置成了8月1日，对日期进行了修改。

我添加这个是否显示“确认”按钮的判断，是在上面遇到的这种情况下，我不需要点击“确认”按钮来修改时间，只需要点击具体的某一天来选择即可。
